### PR TITLE
fix: Improve error handling in fieldFromResolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Stop catching Exceptions in `HandlesGraphqlRequests->fieldFromResolver` to avoid intercepting Exceptions from the service container.
 
 ## [1.2.0] - 2018-09-14
 

--- a/src/Concerns/HandlesGraphqlRequests.php
+++ b/src/Concerns/HandlesGraphqlRequests.php
@@ -16,7 +16,6 @@ use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
 use Illuminate\Validation\ValidationException;
-use ReflectionException;
 
 trait HandlesGraphqlRequests
 {
@@ -121,15 +120,11 @@ trait HandlesGraphqlRequests
         $className = $this->resolveClassName($info);
         $methodName = $this->resolveMethodName($info);
 
-        try {
+        if (app()->has($className) || class_exists($className)) {
             $resolver = app($className);
-        } catch (ReflectionException $e) {
-            // NOTE: It's OK if the class to reflect does not exist
-            $resolver = null;
-        }
-
-        if (method_exists($resolver, $methodName)) {
-            return $resolver->{$methodName}($source, $args, $context, $info);
+            if (method_exists($resolver, $methodName)) {
+                return $resolver->{$methodName}($source, $args, $context, $info);
+            }
         }
     }
 

--- a/tests/HandlesGraphqlRequestsTest.php
+++ b/tests/HandlesGraphqlRequestsTest.php
@@ -232,4 +232,17 @@ class HandlesGraphqlRequestsTest extends AbstractTestCase
             $data
         );
     }
+
+    public function test_fieldFromResolver_doesnt_swallow_errors()
+    {
+        $this->app->config->set('butler.graphql.include_debug_message', true);
+        $this->app->config->set('butler.graphql.include_trace', true);
+
+        $controller = $this->app->make(GraphqlController::class);
+        $data = $controller(Request::create('/', 'POST', [
+            'query' => 'query { nonExistingClassDependency }'
+        ]));
+
+        $this->assertSame("Class Butler\Graphql\Tests\Queries\NonExistingClass does not exist", data_get($data, 'errors.0.debugMessage'));
+    }
 }

--- a/tests/stubs/Queries/NonExistingClassDependency.php
+++ b/tests/stubs/Queries/NonExistingClassDependency.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Butler\Graphql\Tests\Queries;
+
+class NonExistingClassDependency
+{
+    public function __construct(NonExistingClass $nonExistinObject)
+    {
+    }
+
+    public function __invoke($root, $args, $context)
+    {
+        throw new \Exception("This query is used for testing. It should fail in the constructor and never reach the invoke.");
+    }
+}

--- a/tests/stubs/schema.graphql
+++ b/tests/stubs/schema.graphql
@@ -6,6 +6,7 @@ type Query {
     throwModelNotFoundException: String!
     throwValidationException: String!
     ping: String!
+    nonExistingClassDependency: String!
 }
 
 type Mutation {


### PR DESCRIPTION
Avoid catching all ReflectionExceptions. These could indicate that there is no
resolver for the field but it could also be an unrelated error.

Change the implementation to check in the container and with class_exists if
we can instansiate the resolver. This avoids silently swallowing unrelated
exceptions.