### PR TITLE
feat: interface support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: php
 php:
   - '7.1'
   - '7.2'
+  - '7.3'
 
 install:
   - composer install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Interface support 🎉. Types are resolved using `$source['__typename']`, `$source->__typename`, `Parent@resolveTypeForField()` (`Query@resolveType` for queries and mutations) or class base name.
+
 
 ## [1.2.1] - 2018-11-21
 

--- a/tests/HandlesGraphqlRequestsTest.php
+++ b/tests/HandlesGraphqlRequestsTest.php
@@ -262,4 +262,92 @@ class HandlesGraphqlRequestsTest extends AbstractTestCase
             $data
         );
     }
+
+    public function test_resolve_interface_from_query()
+    {
+        $controller = $this->app->make(GraphqlController::class);
+        $data = $controller(Request::create('/', 'POST', [
+            'query' => 'query {
+                resolveInterfaceFromQuery {
+                    __typename
+                    name
+                    size
+                    ... on Photo {
+                        height
+                        width
+                    }
+                    ... on Video {
+                        length
+                    }
+                }
+            }'
+        ]));
+
+        $this->assertSame(
+            [
+                'data' => [
+                    'resolveInterfaceFromQuery' => [
+                        [
+                            '__typename' => 'Photo',
+                            'name' => 'Attachment 1',
+                            'size' => 256,
+                            'height' => 100,
+                            'width' => 200,
+                        ],
+                        [
+                            '__typename' => 'Video',
+                            'name' => 'Attachment 2',
+                            'size' => 1024,
+                            'length' => 3600,
+                        ],
+                        [
+                            '__typename' => 'Photo',
+                            'name' => 'Attachment 3',
+                            'size' => 512,
+                            'height' => 100,
+                            'width' => 200,
+                        ],
+                        [
+                            '__typename' => 'Video',
+                            'name' => 'Attachment 4',
+                            'size' => 2048,
+                            'length' => 7200,
+                        ],
+                    ],
+                ],
+            ],
+            $data
+        );
+    }
+
+    public function test_resolve_interface_from_type()
+    {
+        $controller = $this->app->make(GraphqlController::class);
+        $data = $controller(Request::create('/', 'POST', [
+            'query' => 'query {
+                resolveInterfaceFromType {
+                    name
+                    attachment {
+                        __typename
+                        name
+                    }
+                }
+            }'
+        ]));
+
+        $this->assertSame(
+            [
+                'data' => [
+                    'resolveInterfaceFromType' => [
+                        'name' => 'Thing 1',
+                        'attachment' => [
+                            '__typename' => 'Photo',
+                            'name' => 'Attachment 1',
+                        ],
+                    ],
+                ],
+            ],
+            $data
+        );
+    }
 }

--- a/tests/stubs/Queries/ResolveInterfaceFromQuery.php
+++ b/tests/stubs/Queries/ResolveInterfaceFromQuery.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Butler\Graphql\Tests\Queries;
+
+use Butler\Graphql\Tests\Video;
+use GraphQL\Type\Definition\ResolveInfo;
+
+class ResolveInterfaceFromQuery
+{
+    public function __invoke($root, $args, $context)
+    {
+        return [
+            [
+                'name' => 'Attachment 1',
+                'size' => 256,
+                '__typename' => 'Photo',
+                'height' => 100,
+                'width' => 200,
+            ],
+            (object)[
+                'name' => 'Attachment 2',
+                'size' => 1024,
+                '__typename' => 'Video',
+                'length' => 3600,
+            ],
+            [
+                'name' => 'Attachment 3',
+                'size' => 512,
+                'height' => 100,
+                'width' => 200,
+            ],
+            new Video('Attachment 4', 2048, 7200),
+        ];
+    }
+
+    public function resolveType($source, $context, ResolveInfo $info)
+    {
+        if (is_array($source) && $source['name'] === 'Attachment 3') {
+            return 'Photo';
+        }
+    }
+}

--- a/tests/stubs/Queries/ResolveInterfaceFromType.php
+++ b/tests/stubs/Queries/ResolveInterfaceFromType.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Butler\Graphql\Tests\Queries;
+
+class ResolveInterfaceFromType
+{
+    public function __invoke($root, $args, $context)
+    {
+        return [
+            'name' => 'Thing 1',
+            'attachment' => [
+                'name' => 'Attachment 1',
+                'height' => 100,
+                'width' => 200,
+            ]
+        ];
+    }
+}

--- a/tests/stubs/Types/Thing.php
+++ b/tests/stubs/Types/Thing.php
@@ -26,4 +26,11 @@ class Thing
             return 'typeFieldWithClosure value';
         };
     }
+
+    public function resolveTypeForAttachment($source, $context, ResolveInfo $info)
+    {
+        if (is_array($source) && $source['name'] === 'Attachment 1') {
+            return 'Photo';
+        }
+    }
 }

--- a/tests/stubs/Video.php
+++ b/tests/stubs/Video.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Butler\Graphql\Tests;
+
+class Video
+{
+    public function __construct(string $name, int $size, int $length)
+    {
+        $this->name = $name;
+        $this->size = $size;
+        $this->length = $length;
+    }
+}

--- a/tests/stubs/schema.graphql
+++ b/tests/stubs/schema.graphql
@@ -7,6 +7,8 @@ type Query {
     throwValidationException: String!
     ping: String!
     nonExistingClassDependency: String!
+    resolveInterfaceFromQuery: [Attachment!]!
+    resolveInterfaceFromType: Thing!
 }
 
 type Mutation {
@@ -27,8 +29,27 @@ type Thing {
     typeFieldWithClosure: String!
     missingType: SubThing
     dataLoaded: String!
+    attachment: Attachment
 }
 
 type SubThing {
     name: String!
+}
+
+interface Attachment {
+    name: String!
+    size: Int!
+}
+
+type Photo implements Attachment {
+    name: String!
+    size: Int!
+    height: Int!
+    width: Int!
+}
+
+type Video implements Attachment {
+    name: String!
+    size: Int!
+    length: Int!
 }


### PR DESCRIPTION
Interfaces are now supported and their types are resolved using these methods in the following order:

1. Look for `$source['__typename']` if `$source` is an array.
2. Look for `$source->__typename` if `$source` is an object.
3. Try to call `Parent@resolveTypeFor[Field]()` where `[Field]` is the name of the field. (only `resolveType()` for queries and mutations).
4. Use the base class name of `$source` if it's an object.

Closes #10