### PR TITLE
fix: resolve Boolean values correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- When resolving `Boolean` values from arrays or objects `false` was incorrectly filtered out, resulting in a `null` value instead.
+
 
 ## [2.0.0] - 2019-05-17
 

--- a/src/Concerns/HandlesGraphqlRequests.php
+++ b/src/Concerns/HandlesGraphqlRequests.php
@@ -158,7 +158,9 @@ trait HandlesGraphqlRequests
                 ->map(function ($propertyName) use ($source) {
                     return $source[$propertyName] ?? null;
                 })
-                ->filter()
+                ->reject(function ($value) {
+                    return is_null($value);
+                })
                 ->first();
         }
     }
@@ -170,7 +172,9 @@ trait HandlesGraphqlRequests
                 ->map(function ($propertyName) use ($source) {
                     return $source->{$propertyName} ?? null;
                 })
-                ->filter()
+                ->reject(function ($value) {
+                    return is_null($value);
+                })
                 ->first();
         }
     }

--- a/tests/HandlesGraphqlRequestsTest.php
+++ b/tests/HandlesGraphqlRequestsTest.php
@@ -351,6 +351,33 @@ class HandlesGraphqlRequestsTest extends AbstractTestCase
         );
     }
 
+    public function test_resolves_false_correctly()
+    {
+        $controller = $this->app->make(GraphqlController::class);
+        $data = $controller(Request::create('/', 'POST', [
+            'query' => 'query {
+                resolvesFalseCorrectly {
+                    id
+                    requiredFlag
+                }
+            }'
+        ]));
+
+        $this->assertSame(
+            [
+                'data' => [
+                    'resolvesFalseCorrectly' => [
+                        ['id' => '1', 'requiredFlag' => true],
+                        ['id' => '2', 'requiredFlag' => false],
+                        ['id' => '3', 'requiredFlag' => true],
+                        ['id' => '4', 'requiredFlag' => false],
+                    ],
+                ],
+            ],
+            $data
+        );
+    }
+
     public function test_various_casing()
     {
         $this->app->config->set('butler.graphql.include_debug_message', true);

--- a/tests/stubs/Queries/ResolvesFalseCorrectly.php
+++ b/tests/stubs/Queries/ResolvesFalseCorrectly.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Butler\Graphql\Tests\Queries;
+
+class ResolvesFalseCorrectly
+{
+    public function __invoke($root, $args, $context)
+    {
+        return [
+            ['id' => 1, 'requiredFlag' => true],
+            ['id' => 2, 'requiredFlag' => false],
+            (object)['id' => 3, 'requiredFlag' => true],
+            (object)['id' => 4, 'requiredFlag' => false],
+        ];
+    }
+}

--- a/tests/stubs/schema.graphql
+++ b/tests/stubs/schema.graphql
@@ -10,6 +10,7 @@ type Query {
     resolveInterfaceFromQuery: [Attachment!]!
     resolveInterfaceFromType: Thing!
     variousCasing: [VariousCasing!]!
+    resolvesFalseCorrectly: [AnotherThing!]!
 }
 
 type Mutation {
@@ -35,6 +36,11 @@ type Thing {
 
 type SubThing {
     name: String!
+}
+
+type AnotherThing {
+    id: ID!
+    requiredFlag: Boolean!
 }
 
 interface Attachment {


### PR DESCRIPTION
When resolving `Boolean` values from arrays or objects `false` was incorrectly filtered out, resulting in a `null` value instead.