### PR TITLE
Extend README with information about how to contribute.

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ Customizing what data to collect and include in the response is easily done by c
 
 ## How To Contribute
 
-Development happens at GitHub, any normal workflow with Pull Requests are welcome. In the same spirit the Issue tracker at GitHub is used for any reports (regardless of the nature of the reports - feature requests, bugs of any nature and so on).
+Development happens at GitHub; any typical workflow using Pull Requests are welcome. In the same spirit, we use the GitHub issue tracker for all reports (regardless of the nature of the report, feature request, bugs, etc.).
 
 ### Code standard
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![Build Status](https://img.shields.io/travis/glesys/butler-graphql.svg)](https://travis-ci.org/glesys/butler-graphql)
 [![Packagist](https://img.shields.io/packagist/v/glesys/butler-graphql.svg)](https://packagist.org/packages/glesys/butler-graphql)
 [![License](https://img.shields.io/github/license/glesys/butler-graphql.svg)](LICENCE)
+[![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/3288/badge)](https://bestpractices.coreinfrastructure.org/projects/3288)
 
 
 # Butler GraphQL

--- a/README.md
+++ b/README.md
@@ -321,4 +321,4 @@ Development happens at GitHub, any normal workflow with Pull Requests are welcom
 
 ### Code standard
 
-As the library is intended for use in Laravel applications we encourage code standard to follow [https://laravel.com/docs/master/contributions#coding-style](upstream Laravel practices) - in short that would mean [https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md](PSR-2) and [https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-4-autoloader.md](PSR-4).
+As the library is intended for use in Laravel applications we encourage code standard to follow [upstream Laravel practices](https://laravel.com/docs/master/contributions#coding-style) - in short that would mean [PSR-2](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md) and [PSR-4](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-4-autoloader.md).

--- a/README.md
+++ b/README.md
@@ -313,3 +313,11 @@ composer require barryvdh/laravel-debugbar --dev
 When installed, make sure that `APP_DEBUG` is set to `true`, that's it.
 
 Customizing what data to collect and include in the response is easily done by copying the [default config file](https://github.com/barryvdh/laravel-debugbar/blob/master/config/debugbar.php) to `config/debugbar.php` and adjust as needed.
+
+## How To Contribute
+
+Development happens at GitHub, any normal workflow with Pull Requests are welcome. In the same spirit the Issue tracker at GitHub is used for any reports (regardless of the nature of the reports - feature requests, bugs of any nature and so on).
+
+### Code standard
+
+As the library is intended for use in Laravel applications we encourage code standard to follow [https://laravel.com/docs/master/contributions#coding-style](upstream Laravel practices) - in short that would mean [https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md](PSR-2) and [https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-4-autoloader.md](PSR-4).


### PR DESCRIPTION
Added a contribution section that touches on using a normal github
workflow with pull requests, issues and so on.
Also mention that all types of issues are welcome, security problems
are not supposed to be reported in an alternativ path.

These changes are part of qualification for the CII Best practices
badge.