### PR TITLE
feat: union support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Union support 🎉. Types are resolved using the same technique as for interfaces: `$source['__typename']`, `$source->__typename`, `Parent@resolveTypeForField()` (`Query@resolveType` for queries and mutations) or class base name.
+
 
 ## [3.1.0] - 2020-03-13
 

--- a/src/Concerns/HandlesGraphqlRequests.php
+++ b/src/Concerns/HandlesGraphqlRequests.php
@@ -9,8 +9,9 @@ use GraphQL\Error\Error as GraphqlError;
 use GraphQL\Error\FormattedError;
 use GraphQL\Executor\Promise\PromiseAdapter;
 use GraphQL\GraphQL;
-use GraphQL\Language\AST\TypeDefinitionNode;
 use GraphQL\Language\AST\InterfaceTypeDefinitionNode;
+use GraphQL\Language\AST\TypeDefinitionNode;
+use GraphQL\Language\AST\UnionTypeDefinitionNode;
 use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Utils\BuildSchema;
 use Illuminate\Contracts\Debug\ExceptionHandler;
@@ -101,10 +102,16 @@ trait HandlesGraphqlRequests
 
     public function decorateTypeConfig(array $config, TypeDefinitionNode $typeDefinitionNode)
     {
-        if ($typeDefinitionNode instanceof InterfaceTypeDefinitionNode) {
+        if ($this->shouldDecorateWithResolveType($typeDefinitionNode)) {
             $config['resolveType'] = [$this, 'resolveType'];
         }
         return $config;
+    }
+
+    protected function shouldDecorateWithResolveType(TypeDefinitionNode $typeDefinitionNode)
+    {
+        return $typeDefinitionNode instanceof InterfaceTypeDefinitionNode
+            || $typeDefinitionNode instanceof UnionTypeDefinitionNode;
     }
 
     public function debugFlags()

--- a/tests/HandlesGraphqlRequestsTest.php
+++ b/tests/HandlesGraphqlRequestsTest.php
@@ -258,7 +258,10 @@ class HandlesGraphqlRequestsTest extends AbstractTestCase
             'query' => 'query { nonExistingClassDependency }'
         ]));
 
-        $this->assertSame("Class Butler\Graphql\Tests\Queries\NonExistingClass does not exist", data_get($data, 'errors.0.debugMessage'));
+        $this->assertContains(data_get($data, 'errors.0.debugMessage'), [
+            "Class Butler\Graphql\Tests\Queries\NonExistingClass does not exist", // Laravel < 6.0
+            "Target class [Butler\Graphql\Tests\Queries\NonExistingClass] does not exist.", // Laravel >= 6.0
+        ]);
     }
 
     public function test_operationName()

--- a/tests/stubs/Queries/ResolveUnionFromQuery.php
+++ b/tests/stubs/Queries/ResolveUnionFromQuery.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Butler\Graphql\Tests\Queries;
+
+use Exception;
+
+class ResolveUnionFromQuery
+{
+    public function __invoke($root, $args, $context)
+    {
+        return [
+            ['name' => 'Soundtrack 1', 'size' => 1024, 'encoding' => 'mp3', '__typename' => 'Audio'],
+            (object) ['name' => 'Soundtrack 2', 'size' => 2048, 'encoding' => 'mp3', '__typename' => 'Audio'],
+            ['name' => 'Soundtrack 3', 'size' => 4096, 'encoding' => 'mp3'],
+            ['name' => 'Photo 1', 'size' => 256, 'height' => 100, 'width' => 200, '__typename' => 'Photo'],
+            (object)['name' => 'Video 2', 'size' => 512, 'length' => 3600, '__typename' => 'Video'],
+        ];
+    }
+
+    public function resolveType($source)
+    {
+        if ($source['name'] ?? null === 'Soundtrack 3') {
+            return 'Audio';
+        }
+        throw new Exception('Should never be reached');
+    }
+}

--- a/tests/stubs/Queries/ResolveUnionFromType.php
+++ b/tests/stubs/Queries/ResolveUnionFromType.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Butler\Graphql\Tests\Queries;
+
+class ResolveUnionFromType
+{
+    public function __invoke($root, $args, $context)
+    {
+        return [
+            'name' => 'Thing 1',
+            'media' => [
+                'name' => 'Video 1',
+                'size' => 1024,
+                'length' => 3600,
+            ]
+        ];
+    }
+}

--- a/tests/stubs/Types/Thing.php
+++ b/tests/stubs/Types/Thing.php
@@ -3,6 +3,7 @@
 namespace Butler\Graphql\Tests\Types;
 
 use Closure;
+use Exception;
 use GraphQL\Type\Definition\ResolveInfo;
 
 class Thing
@@ -69,5 +70,14 @@ class Thing
         if (is_array($source) && $source['name'] === 'Attachment 1') {
             return 'Photo';
         }
+        throw new Exception('Should never be reached');
+    }
+
+    public function resolveTypeForMedia($source, $context, ResolveInfo $info)
+    {
+        if (is_array($source) && $source['name'] === 'Video 1') {
+            return 'Video';
+        }
+        throw new Exception('Should never be reached');
     }
 }

--- a/tests/stubs/schema.graphql
+++ b/tests/stubs/schema.graphql
@@ -9,6 +9,8 @@ type Query {
     nonExistingClassDependency: String!
     resolveInterfaceFromQuery: [Attachment!]!
     resolveInterfaceFromType: Thing!
+    resolveUnionFromQuery: [Media!]!
+    resolveUnionFromType: Thing!
     variousCasing: [VariousCasing!]!
     resolvesFalseCorrectly: [AnotherThing!]!
 }
@@ -34,6 +36,7 @@ type Thing {
     sharedDataLoaderOne: String!
     sharedDataLoaderTwo: String!
     attachment: Attachment
+    media: Media
 }
 
 type SubThing {
@@ -62,6 +65,14 @@ type Video implements Attachment {
     size: Int!
     length: Int!
 }
+
+type Audio {
+    name: String!
+    size: Int!
+    encoding: String!
+}
+
+union Media = Audio | Photo | Video
 
 type VariousCasing {
     name: String!


### PR DESCRIPTION
Union support 🎉

Types are resolved using the same technique as for interfaces: `$source['__typename']`, `$source->__typename`, `Parent@resolveTypeForField()` (`Query@resolveType` for queries and mutations) or class base name.