### PR TITLE
Add automatic dependency checking using dependabot.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "composer"
+    directory: "/"
+    rebase-strategy: "disabled"
+    open-pull-requests-limit: 2
+    schedule:
+      interval: "weekly"
+      day: "thursday"

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,6 @@ matrix:
         - PHPUNIT_VERSION=^9.0
 
 before_install:
-  - composer global require hirak/prestissimo --no-plugins
   - composer require "laravel/framework:${LARAVEL_VERSION}" --no-update
   - composer require "phpunit/phpunit:${PHPUNIT_VERSION}" --dev --no-update
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: php
+os: linux
 
-matrix:
+jobs:
   include:
     - php: 7.2.5
       env:


### PR DESCRIPTION
Adding a configuration file for checking the composer
dependencies every Thursday. It will open a PR if needed be,
maximum 2 PRs can be opened - every two weeks an action must be
made. Should be possible to cope with.

These changes are part of qualification for the CII Best practices
silver badge.

From the [checklist](https://bestpractices.coreinfrastructure.org/en/projects/3288/edit?criteria_level=1#quality) (see "externally maintained components"):
> 
> Projects MUST monitor or periodically check their external dependencies (including convenience copies) to detect known vulnerabilities, and fix exploitable vulnerabilities or verify them as unexploitable. 
> 
> This can be done using an origin analyzer / dependency checking tool / software composition analysis tool such as OWASP's Dependency-Check, Sonatype's Nexus Auditor, Synopsys' Black Duck Software Composition Analysis, and Bundler-audit (for Ruby). Some package managers include mechanisms to do this. It is acceptable if the components' vulnerability cannot be exploited, but this analysis is difficult and it is sometimes easier to simply update or fix the part. 