### PR TITLE
Support passing php Enums to resolvers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **BREAKING**: Support passing php Enums to resolvers.
 
 ## [7.1.0] - 2022-03-15
 

--- a/src/Concerns/HandlesGraphqlRequests.php
+++ b/src/Concerns/HandlesGraphqlRequests.php
@@ -183,13 +183,10 @@ trait HandlesGraphqlRequests
     {
         $field = $this->fieldFromResolver($source, $args, $context, $info)
             ?? $this->fieldFromArray($source, $args, $context, $info)
-            ?? $this->fieldFromObject($source, $args, $context, $info);
+            ?? $this->fieldFromObject($source, $args, $context, $info)
+            ?? $this->fieldFromEnum($source, $args, $context, $info);
 
         return call(static function () use ($field, $source, $args, $context, $info) {
-            if (function_exists('enum_exists') && $field instanceof \BackedEnum) {
-                return $field->value;
-            }
-
             return $field instanceof \Closure
                 ? $field($source, $args, $context, $info)
                 : $field;
@@ -241,6 +238,13 @@ trait HandlesGraphqlRequests
                     return is_null($value);
                 })
                 ->first();
+        }
+    }
+
+    public function fieldFromEnum($source, $args, $context, ResolveInfo $info)
+    {
+        if (function_exists('enum_exists') && $source instanceof \BackedEnum) {
+            return $source->value;
         }
     }
 

--- a/tests/HandlesGraphqlRequestsTest.php
+++ b/tests/HandlesGraphqlRequestsTest.php
@@ -35,7 +35,6 @@ class HandlesGraphqlRequestsTest extends AbstractTestCase
                     name,
                     typeField,
                     typeFieldWithClosure,
-                    typeFieldWithEnum,
                     missingType {
                         name
                     }
@@ -51,25 +50,60 @@ class HandlesGraphqlRequestsTest extends AbstractTestCase
                             'name' => 'Thing 1',
                             'typeField' => 'typeField value',
                             'typeFieldWithClosure' => 'typeFieldWithClosure value',
-                            'typeFieldWithEnum' => 'foo',
                             'missingType' => null,
                         ],
                         [
                             'name' => 'Thing 2',
                             'typeField' => 'typeField value',
                             'typeFieldWithClosure' => 'typeFieldWithClosure value',
-                            'typeFieldWithEnum' => 'foo',
                             'missingType' => null,
                         ],
                         [
                             'name' => 'Thing 3',
                             'typeField' => 'typeField value',
                             'typeFieldWithClosure' => 'typeFieldWithClosure value',
-                            'typeFieldWithEnum' => 'foo',
                             'missingType' => [
                                 'name' => 'Sub Thing',
                             ],
                         ],
+                    ],
+                ],
+            ],
+            $data
+        );
+    }
+
+    public function test_enum_resolvers()
+    {
+        if (PHP_VERSION_ID < 80100) {
+            $this->markTestSkipped("Enums not supported in current php version.");
+        }
+
+        $this->app->config->set('butler.graphql.include_debug_message', true);
+        $this->app->config->set('butler.graphql.include_trace', true);
+
+        $controller = $this->app->make(GraphqlController::class);
+        $data = $controller(Request::create('/', 'POST', [
+            'query' => 'query {
+                testEnumResolvers {
+                    fieldBackedByEnum
+                    fieldBackedByResolverForEnum
+                }
+            }'
+        ]));
+
+        $this->assertSame(
+            [
+                'data' => [
+                    'testEnumResolvers' => [
+                        [
+                            'fieldBackedByEnum' => 'foo',
+                            'fieldBackedByResolverForEnum' => 'FOO:foo',
+                        ],
+                        [
+                            'fieldBackedByEnum' => 'bar',
+                            'fieldBackedByResolverForEnum' => 'BAR:bar',
+                        ]
                     ],
                 ],
             ],

--- a/tests/stubs/Queries/TestEnumResolvers.php
+++ b/tests/stubs/Queries/TestEnumResolvers.php
@@ -1,0 +1,18 @@
+<?php // phpcs:disable PSR1.Files.SideEffects.FoundWithSymbols
+
+namespace Butler\Graphql\Tests\Queries;
+
+if (PHP_VERSION_ID >= 80100) {
+    require_once __DIR__ . '/../enums.php';
+}
+
+class TestEnumResolvers
+{
+    public function __invoke($root, $args, $context)
+    {
+        return [
+            \ThingStatus::FOO,
+            \ThingStatus::BAR,
+        ];
+    }
+}

--- a/tests/stubs/Types/EnumThing.php
+++ b/tests/stubs/Types/EnumThing.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Butler\Graphql\Tests\Types;
+
+use GraphQL\Type\Definition\ResolveInfo;
+
+class EnumThing
+{
+    public function fieldBackedByResolverForEnum(\ThingStatus $source, $args, $context, ResolveInfo $info)
+    {
+        return "{$source->name}:{$source->value}";
+    }
+}

--- a/tests/stubs/Types/Thing.php
+++ b/tests/stubs/Types/Thing.php
@@ -1,4 +1,4 @@
-<?php // phpcs:disable PSR1.Files.SideEffects.FoundWithSymbols
+<?php
 
 namespace Butler\Graphql\Tests\Types;
 
@@ -7,10 +7,6 @@ use Butler\Graphql\Tests\TypedThing;
 use Closure;
 use Exception;
 use GraphQL\Type\Definition\ResolveInfo;
-
-if (PHP_VERSION_ID >= 80100) {
-    require __DIR__ . '/../enums.php';
-}
 
 class Thing
 {
@@ -119,15 +115,6 @@ class Thing
         return function () {
             return 'typeFieldWithClosure value';
         };
-    }
-
-    public function typeFieldWithEnum($source, $args, $context, ResolveInfo $info)
-    {
-        if (function_exists('enum_exists') && enum_exists(\ThingStatus::class)) {
-            return \ThingStatus::FOO;
-        }
-
-        return 'foo';
     }
 
     public function resolveTypeForAttachment($source, $context, ResolveInfo $info)

--- a/tests/stubs/schema.graphql
+++ b/tests/stubs/schema.graphql
@@ -1,5 +1,6 @@
 type Query {
     testResolvers: [Thing]
+    testEnumResolvers: [EnumThing]
     dataLoader: [Thing]
     dataLoaderWithCollections: [Thing!]!
     throwError: String!
@@ -34,7 +35,6 @@ type Thing {
     name: String!
     typeField: String!
     typeFieldWithClosure: String!
-    typeFieldWithEnum: String!
     missingType: SubThing
     dataLoaded: String!
     dataLoadedByKey: String!
@@ -46,6 +46,11 @@ type Thing {
     attachment: Attachment
     media: Media
     subThings: [SubThing!]
+}
+
+type EnumThing {
+    fieldBackedByEnum: String!
+    fieldBackedByResolverForEnum: String!
 }
 
 type SubThing {


### PR DESCRIPTION
Currently, all enums are converted to strings by the library.

This patch changes that behavior by only converting enums to strings
if no other resolvers could be found for the field. This enables passing
enums to resolvers/types.