### PR TITLE
Cast backed enum to its value when return type is a 'leaf'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Cast backed enum to its value when return type is a "leaf" (enum or scalar).
+
 ## [8.0.0] - 2022-04-27
 
 ### Changed

--- a/tests/HandlesGraphqlRequestsTest.php
+++ b/tests/HandlesGraphqlRequestsTest.php
@@ -86,8 +86,14 @@ class HandlesGraphqlRequestsTest extends AbstractTestCase
         $data = $controller(Request::create('/', 'POST', [
             'query' => 'query {
                 testEnumResolvers {
-                    fieldBackedByEnum
-                    fieldBackedByResolverForEnum
+                    name
+                    enum
+                    typeFieldEnum
+                    typeFieldString
+                    subEnum {
+                        name
+                        value
+                    }
                 }
             }'
         ]));
@@ -97,12 +103,18 @@ class HandlesGraphqlRequestsTest extends AbstractTestCase
                 'data' => [
                     'testEnumResolvers' => [
                         [
-                            'fieldBackedByEnum' => 'foo',
-                            'fieldBackedByResolverForEnum' => 'FOO:foo',
+                            'name' => 'Enum Thing 1',
+                            'enum' => 'foo',
+                            'typeFieldEnum' => 'foo',
+                            'typeFieldString' => 'FOO:foo',
+                            'subEnum' => ['name' => 'ZAB', 'value' => 'baz'],
                         ],
                         [
-                            'fieldBackedByEnum' => 'bar',
-                            'fieldBackedByResolverForEnum' => 'BAR:bar',
+                            'name' => 'Enum Thing 2',
+                            'enum' => 'bar',
+                            'typeFieldEnum' => 'bar',
+                            'typeFieldString' => 'BAR:bar',
+                            'subEnum' => ['name' => 'ZAB', 'value' => 'baz'],
                         ]
                     ],
                 ],

--- a/tests/stubs/Queries/TestEnumResolvers.php
+++ b/tests/stubs/Queries/TestEnumResolvers.php
@@ -11,8 +11,8 @@ class TestEnumResolvers
     public function __invoke($root, $args, $context)
     {
         return [
-            \ThingStatus::FOO,
-            \ThingStatus::BAR,
+            ['name' => 'Enum Thing 1', 'enum' => \ThingEnum::FOO],
+            ['name' => 'Enum Thing 2', 'enum' => \ThingEnum::BAR],
         ];
     }
 }

--- a/tests/stubs/Types/EnumThing.php
+++ b/tests/stubs/Types/EnumThing.php
@@ -6,8 +6,18 @@ use GraphQL\Type\Definition\ResolveInfo;
 
 class EnumThing
 {
-    public function fieldBackedByResolverForEnum(\ThingStatus $source, $args, $context, ResolveInfo $info)
+    public function typeFieldEnum($source, $args, $context, ResolveInfo $info)
     {
-        return "{$source->name}:{$source->value}";
+        return $source['enum'];
+    }
+
+    public function typeFieldString($source, $args, $context, ResolveInfo $info)
+    {
+        return "{$source['enum']->name}:{$source['enum']->value}";
+    }
+
+    public function subEnum($source, $args, $context, ResolveInfo $info)
+    {
+        return \SubEnum::BAZ;
     }
 }

--- a/tests/stubs/Types/SubEnum.php
+++ b/tests/stubs/Types/SubEnum.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Butler\Graphql\Tests\Types;
+
+class SubEnum
+{
+    public function name($source)
+    {
+        return strrev($source->name);
+    }
+}

--- a/tests/stubs/enums.php
+++ b/tests/stubs/enums.php
@@ -1,7 +1,12 @@
 <?php // phpcs:disable
 
-enum ThingStatus: string
+enum ThingEnum: string
 {
     case FOO = 'foo';
     case BAR = 'bar';
+}
+
+enum SubEnum: string
+{
+    case BAZ = 'baz';
 }

--- a/tests/stubs/schema.graphql
+++ b/tests/stubs/schema.graphql
@@ -49,13 +49,21 @@ type Thing {
 }
 
 type EnumThing {
-    fieldBackedByEnum: String!
-    fieldBackedByResolverForEnum: String!
+    name: String!
+    enum: String!
+    typeFieldEnum: String!
+    typeFieldString: String!
+    subEnum: SubEnum!
 }
 
 type SubThing {
     name: String!
     thing: Thing
+}
+
+type SubEnum {
+    name: String!
+    value: String!
 }
 
 type AnotherThing {


### PR DESCRIPTION
tldr; Eloquent models casting enums was catched by the `fieldFromArray` (because of `ArrayAccess`) and the enum instance was returned instead of its value resulting in a "Expected a value of type "MyEnum" but received: instance of App\Enums\MyEnum" error.