### PR TITLE
Support for eloquent strictness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Support for [eloquent strictness](https://laravel.com/docs/9.x/eloquent#configuring-eloquent-strictness).
 
 ## [8.0.1] - 2022-05-05
 

--- a/src/Concerns/HandlesGraphqlRequests.php
+++ b/src/Concerns/HandlesGraphqlRequests.php
@@ -21,6 +21,7 @@ use GraphQL\Type\Definition\WrappingType;
 use GraphQL\Type\Schema;
 use GraphQL\Utils\BuildSchema;
 use Illuminate\Contracts\Debug\ExceptionHandler;
+use Illuminate\Database\Eloquent\MissingAttributeException;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
@@ -223,7 +224,11 @@ trait HandlesGraphqlRequests
         if (is_array($source) || $source instanceof \ArrayAccess) {
             return collect($this->propertyNames($info))
                 ->map(function ($propertyName) use ($source) {
-                    return $source[$propertyName] ?? null;
+                    try {
+                        return $source[$propertyName] ?? null;
+                    } catch (MissingAttributeException) {
+                        return null;
+                    }
                 })
                 ->reject(function ($value) {
                     return is_null($value);
@@ -237,7 +242,11 @@ trait HandlesGraphqlRequests
         if (is_object($source)) {
             return collect($this->propertyNames($info))
                 ->map(function ($propertyName) use ($source) {
-                    return $source->{$propertyName} ?? null;
+                    try {
+                        return $source->{$propertyName} ?? null;
+                    } catch (MissingAttributeException) {
+                        return null;
+                    }
                 })
                 ->reject(function ($value) {
                     return is_null($value);

--- a/tests/stubs/GraphqlControllerWithEloquentStrictness.php
+++ b/tests/stubs/GraphqlControllerWithEloquentStrictness.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Butler\Graphql\Tests;
+
+use Butler\Graphql\Concerns\HandlesGraphqlRequests;
+use Illuminate\Database\Eloquent\Model;
+
+class GraphqlControllerWithEloquentStrictness
+{
+    use HandlesGraphqlRequests;
+
+    public function __construct()
+    {
+        Model::preventAccessingMissingAttributes(true);
+    }
+}

--- a/tests/stubs/Queries/StrictEloquentModel.php
+++ b/tests/stubs/Queries/StrictEloquentModel.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Butler\Graphql\Tests\Queries;
+
+use Illuminate\Database\Eloquent\Model;
+
+class StrictEloquentModel
+{
+    public function __invoke($root, $args, $context)
+    {
+        return new class extends Model {
+            public $exists = true;
+
+            protected $attributes = [
+                'id' => '100',
+                'is_strict' => true,
+            ];
+        };
+    }
+}

--- a/tests/stubs/schema.graphql
+++ b/tests/stubs/schema.graphql
@@ -17,6 +17,7 @@ type Query {
     variousCasing: [VariousCasing!]!
     resolvesFalseCorrectly: [AnotherThing!]!
     thingsWithSubThings: [Thing!]!
+    strictEloquentModel: StrictEloquentModel!
 }
 
 type Mutation {
@@ -69,6 +70,11 @@ type SubEnum {
 type AnotherThing {
     id: ID!
     requiredFlag: Boolean!
+}
+
+type StrictEloquentModel {
+    id: ID!
+    isStrict: Boolean!
 }
 
 interface Attachment {


### PR DESCRIPTION
https://laravel.com/docs/9.x/eloquent#configuring-eloquent-strictness

Since we're resolving fields in snake, camel and kebab case a `MissingAttributeException` is thrown when eloquent is configured with `$modelsShouldPreventAccessingMissingAttributes`.