### PR TITLE
Exclusively use the field resolver if one is available.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **BREAKING** Fields that uses a resolver method are now exclusively resolved using that method. Previously, if a resolver method returned `null`, the library would continue to try and resolve the field using the built in array and object resolvers.
 
 ## [8.1.0] - 2022-10-18
 

--- a/tests/HandlesGraphqlRequestsTest.php
+++ b/tests/HandlesGraphqlRequestsTest.php
@@ -786,4 +786,30 @@ class HandlesGraphqlRequestsTest extends AbstractTestCase
             $data
         );
     }
+
+    public function test_custom_resolver_skips_array_and_object_resolving()
+    {
+        $controller = $this->app->make(GraphqlController::class);
+        $data = $controller(Request::create('/', 'POST', [
+            'query' => 'query {
+                testFieldResolver {
+                    message
+                }
+            }'
+        ]));
+
+        $this->assertSame(
+            [
+                'data' => [
+                    'testFieldResolver' => [
+                        ['message' => null],
+                        ['message' => null],
+                        ['message' => null],
+                        ['message' => null],
+                    ]
+                ],
+            ],
+            $data
+        );
+    }
 }

--- a/tests/stubs/Queries/TestFieldResolver.php
+++ b/tests/stubs/Queries/TestFieldResolver.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Butler\Graphql\Tests\Queries;
+
+class TestFieldResolver
+{
+    public function __invoke($root, $args, $context)
+    {
+        return [
+            ['message' => null],
+            ['message' => 'foo'],
+            collect(),
+            (object) ['message' => 'foo'],
+        ];
+    }
+}

--- a/tests/stubs/Types/NullingType.php
+++ b/tests/stubs/Types/NullingType.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Butler\Graphql\Tests\Types;
+
+class NullingType
+{
+    public function message()
+    {
+        return null;
+    }
+}

--- a/tests/stubs/schema.graphql
+++ b/tests/stubs/schema.graphql
@@ -1,6 +1,7 @@
 type Query {
     testResolvers: [Thing]
     testEnumResolvers: [EnumThing]
+    testFieldResolver: [NullingType!]!
     dataLoader: [Thing]
     dataLoaderWithCollections: [Thing!]!
     throwError: String!
@@ -22,6 +23,10 @@ type Query {
 
 type Mutation {
     testMutation(input: TestMutationInput): TestMutationPayload
+}
+
+type NullingType {
+    message: String
 }
 
 input TestMutationInput {


### PR DESCRIPTION
Before this change, the `fieldFromArray` and `fieldFromObject` methods were always used to try to resolve a field, even if a specific field resolver was available, if null was returned from the resolver.

Specifying a specific resolver for a field is a way to "override" the custom field resolving behavior (`fieldFromArray` and `fieldFromObject`).

With this change, we will take the value from the field resolver as the value for the field, even if the value happens to be null and not continue resolving the source as an array or object.