### PR TITLE
Handle empty schema extension config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Handle empty schema extension config.
 
 ## [10.1.0] - 2024-02-02
 

--- a/src/Concerns/HandlesGraphqlRequests.php
+++ b/src/Concerns/HandlesGraphqlRequests.php
@@ -174,10 +174,16 @@ trait HandlesGraphqlRequests
 
     public function schemaExtensions()
     {
-        $path = Str::finish($this->schemaExtensionsPath(), DIRECTORY_SEPARATOR);
+        $path = $this->schemaExtensionsPath();
         $glob = $this->schemaExtensionsGlob();
 
-        return collect(glob("{$path}{$glob}"))->map(file_get_contents(...))->toArray();
+        if ($path && $glob) {
+            $path = Str::finish($path, DIRECTORY_SEPARATOR);
+
+            return collect(glob("{$path}{$glob}"))->map(file_get_contents(...))->toArray();
+        }
+
+        return [];
     }
 
     public function schemaExtensionsPath()


### PR DESCRIPTION
If `butler.graphql.schema_extensions_path` and `butler.graphql.schema_extensions_glob` is missing or empty the glob will be `/`...