### PR TITLE
Update data loader behaviour for integer ID-based "associative" keys

### DIFF
--- a/pint.json
+++ b/pint.json
@@ -10,6 +10,11 @@
                 "method" : "one",
                 "trait_import" : "none"
             }
-        }
+        },
+        "new_with_parentheses": {
+            "anonymous_class": false,
+            "named_class": true
+        },
+        "php_unit_method_casing": false
     }
 }

--- a/src/Concerns/HandlesGraphqlRequests.php
+++ b/src/Concerns/HandlesGraphqlRequests.php
@@ -96,9 +96,7 @@ trait HandlesGraphqlRequests
         DocumentNode $query,
         ?string $operationName = null,
         $variables = null
-    ): void {
-
-    }
+    ): void {}
 
     public function errorFormatter(GraphqlError $graphqlError)
     {

--- a/src/DataLoader.php
+++ b/src/DataLoader.php
@@ -5,6 +5,7 @@ namespace Butler\Graphql;
 use Amp\Deferred;
 use Amp\Loop;
 use Closure;
+use Illuminate\Contracts\Support\Arrayable;
 use ReflectionFunction;
 
 class DataLoader
@@ -82,9 +83,10 @@ class DataLoader
 
                 $result = ($this->batchLoadFunction)($indexedOriginalKeys);
 
-                $currentIndex = 0;
+                $resultIsList = array_is_list($result instanceof Arrayable ? $result->toArray() : $result);
+
                 foreach ($result as $key => $value) {
-                    if ($key === $currentIndex) {
+                    if ($resultIsList) {
                         $key = $indexedOriginalKeys[$key] ?? $key;
                     }
                     $key = self::serializeKey($key);
@@ -93,8 +95,6 @@ class DataLoader
                         $deferred->resolve($value);
                         unset($this->deferredPromises[$key]);
                     }
-
-                    $currentIndex++;
                 }
 
                 foreach ($this->deferredPromises as $key => [$deferredPromise]) {

--- a/tests/HandlesGraphqlRequestsTest.php
+++ b/tests/HandlesGraphqlRequestsTest.php
@@ -145,6 +145,7 @@ class HandlesGraphqlRequestsTest extends AbstractTestCase
                 dataLoader {
                     dataLoaded
                     dataLoadedByKey
+                    dataLoadedByIntegerKey
                     dataLoadedUsingArray
                     dataLoadedUsingObject
                     dataLoadedWithDefault
@@ -161,6 +162,7 @@ class HandlesGraphqlRequestsTest extends AbstractTestCase
                         [
                             'dataLoaded' => 'THING 1',
                             'dataLoadedByKey' => 'By key: Thing 1',
+                            'dataLoadedByIntegerKey' => 'By integer key: Thing 1',
                             'dataLoadedUsingArray' => 'As array: Thing 1',
                             'dataLoadedUsingObject' => 'As object: Thing 1',
                             'dataLoadedWithDefault' => 'Thing 1',
@@ -170,6 +172,7 @@ class HandlesGraphqlRequestsTest extends AbstractTestCase
                         [
                             'dataLoaded' => 'THING 2',
                             'dataLoadedByKey' => 'By key: Thing 2',
+                            'dataLoadedByIntegerKey' => 'By integer key: Thing 2',
                             'dataLoadedUsingArray' => 'As array: Thing 2',
                             'dataLoadedUsingObject' => 'As object: Thing 2',
                             'dataLoadedWithDefault' => 'default value',

--- a/tests/HandlesGraphqlRequestsTest.php
+++ b/tests/HandlesGraphqlRequestsTest.php
@@ -16,7 +16,7 @@ use Mockery;
 
 class HandlesGraphqlRequestsTest extends AbstractTestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/stubs/Queries/DataLoader.php
+++ b/tests/stubs/Queries/DataLoader.php
@@ -7,8 +7,8 @@ class DataLoader
     public function __invoke($root, $args, $context)
     {
         return [
-            ['name' => 'Thing 1'],
-            ['name' => 'Thing 2'],
+            ['id' => 1, 'name' => 'Thing 1'],
+            ['id' => 2, 'name' => 'Thing 2'],
         ];
     }
 }

--- a/tests/stubs/Queries/NonExistingClassDependency.php
+++ b/tests/stubs/Queries/NonExistingClassDependency.php
@@ -4,9 +4,7 @@ namespace Butler\Graphql\Tests\Queries;
 
 class NonExistingClassDependency
 {
-    public function __construct(NonExistingClass $nonExistinObject)
-    {
-    }
+    public function __construct(NonExistingClass $nonExistinObject) {}
 
     public function __invoke($root, $args, $context)
     {

--- a/tests/stubs/Types/Thing.php
+++ b/tests/stubs/Types/Thing.php
@@ -39,6 +39,18 @@ class Thing
         })->load($source['name']);
     }
 
+    public function dataLoadedByIntegerKey($source, $args, $context, ResolveInfo $info)
+    {
+        return $context['loader'](function () {
+            // NOTE: The order of these keys is important for testing the ability
+            // to differentiate between index-based and integer-based keys.
+            return [
+                2 => 'By integer key: Thing 2',
+                1 => 'By integer key: Thing 1',
+            ];
+        })->load((int) $source['id']);
+    }
+
     public function dataLoadedWithDefault($source, $args, $context, ResolveInfo $info)
     {
         return $context['loader'](function () {

--- a/tests/stubs/schema.graphql
+++ b/tests/stubs/schema.graphql
@@ -45,6 +45,7 @@ type Thing {
     missingType: SubThing
     dataLoaded: String!
     dataLoadedByKey: String!
+    dataLoadedByIntegerKey: String!
     dataLoadedUsingArray: String!
     dataLoadedUsingObject: String!
     dataLoadedWithDefault: String!


### PR DESCRIPTION
The prior logic for determining whether a data loader result was index-based or contained associative keys was flawed. This could lead to a problematic situation in which integer IDs were used as "associative" keys while posing the risk of "matching" an index:

Index-based array: `[0 => ..., 1 => ..., 2 => ...]`

Integer ID-based array: `[2 => ..., 1 => ..., 3 => ...]`

Since the previous logic performed this check for each iteration instead of once for the entire result, it interpreted the second item in the integer ID-based array above as index-based (since ID 1 corresponds to index 1).

This commit updates the logic to use `array_is_list()` to prevent this flaw.