### PR TITLE
Upgrade to webonyx/graphql-php:^15.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,8 +6,8 @@ jobs:
     name: Testing with Laravel ${{ matrix.laravel }} and PHP ${{ matrix.php }}
     strategy:
         matrix:
-            php: [8.2, 8.3]
-            laravel: [^11.0]
+            php: [8.2, 8.3, 8.4]
+            laravel: [^11.0, ^12.0]
     steps:
       - uses: actions/checkout@v2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **BREAKING**: Require `webonyx/graphql-php:^15.0`. This is a breaking change if you use `include_debug_message` or `include_trace`. The fields `debugMessage` and `trace` will no longer be present in the root payload of the errors, but instead under the `extensions: { ... }` object.
+
 
 ## [11.0.1] - 2025-04-22
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,3 +1,13 @@
+## Upgrade from v11 to v12
+
+### BREAKING: Require `webonyx/graphql-php:^15.0`.
+
+If you use `include_debug_message` or `include_trace` the fields `debugMessage` and `trace` will no longer be present in the root payload of the errors, but instead under the `extensions: { ... }` object.
+
+- `errors.*.debugMessage` is now `errors.*.extensions.debugMessage`.
+- `errors.*.trace` is now `errors.*.extensions.trace`.
+
+
 ## Upgrade from v4 to v5
 
 ### BREAKING: Promises are based on `amphp/amp` instead of `react/promise`

--- a/composer.json
+++ b/composer.json
@@ -41,15 +41,15 @@
     "name": "glesys/butler-graphql",
     "require": {
         "php": "^8.2",
-        "amphp/amp": "^2.5",
-        "illuminate/support": "^11.0",
-        "webonyx/graphql-php": "^14.3.0"
+        "amphp/amp": "^2.6",
+        "illuminate/support": "^11.0 || ^12.0",
+        "webonyx/graphql-php": "^15.0"
     },
     "require-dev": {
         "graham-campbell/testbench": "^6.0",
         "laravel/pint": "^1.14",
         "mockery/mockery": "^1.4.4",
-        "phpunit/phpunit": "^10.0"
+        "phpunit/phpunit": "^10.0 || ^11.0"
     },
     "suggest": {
         "barryvdh/laravel-debugbar": "View debug information in responses."

--- a/src/Concerns/HandlesGraphqlRequests.php
+++ b/src/Concerns/HandlesGraphqlRequests.php
@@ -100,7 +100,12 @@ trait HandlesGraphqlRequests
 
     public function errorFormatter(GraphqlError $graphqlError)
     {
-        $formattedError = FormattedError::createFromException($graphqlError);
+        $formattedError = array_merge(FormattedError::createFromException($graphqlError), [
+            'extensions' => [
+                'category' => 'internal',
+            ],
+        ]);
+
         $throwable = $graphqlError->getPrevious();
 
         $this->reportException(

--- a/tests/HandlesGraphqlRequestsTest.php
+++ b/tests/HandlesGraphqlRequestsTest.php
@@ -226,8 +226,8 @@ class HandlesGraphqlRequestsTest extends AbstractTestCase
             'query' => 'query { throwException }',
         ]));
 
-        $this->assertFalse(Arr::has($data, 'errors.0.debugMessage'), 'debugMessage should not be included');
-        $this->assertFalse(Arr::has($data, 'errors.0.trace'), 'trace should not be included');
+        $this->assertFalse(Arr::has($data, 'errors.0.extensions.debugMessage'), 'debugMessage should not be included');
+        $this->assertFalse(Arr::has($data, 'errors.0.extensions.trace'), 'trace should not be included');
         $this->assertSame('Internal server error', Arr::get($data, 'errors.0.message'));
         $this->assertSame('internal', Arr::get($data, 'errors.0.extensions.category'));
     }
@@ -267,8 +267,8 @@ class HandlesGraphqlRequestsTest extends AbstractTestCase
             'query' => 'query { throwException }',
         ]));
 
-        $this->assertFalse(Arr::has($data, 'errors.0.trace'), 'trace should not be included');
-        $this->assertSame('An error occured', Arr::get($data, 'errors.0.debugMessage'));
+        $this->assertFalse(Arr::has($data, 'errors.0.extensions.trace'), 'trace should not be included');
+        $this->assertSame('An error occured', Arr::get($data, 'errors.0.extensions.debugMessage'));
         $this->assertSame('Internal server error', Arr::get($data, 'errors.0.message'));
         $this->assertSame('internal', Arr::get($data, 'errors.0.extensions.category'));
     }
@@ -282,8 +282,8 @@ class HandlesGraphqlRequestsTest extends AbstractTestCase
             'query' => 'query { throwException }',
         ]));
 
-        $this->assertFalse(Arr::has($data, 'errors.0.debugMessage'), 'debugMessage should not be included');
-        $this->assertGreaterThan(10, Arr::get($data, 'errors.0.trace'));
+        $this->assertFalse(Arr::has($data, 'errors.0.extensions.debugMessage'), 'debugMessage should not be included');
+        $this->assertGreaterThan(10, Arr::get($data, 'errors.0.extensions.trace'));
         $this->assertSame('Internal server error', Arr::get($data, 'errors.0.message'));
         $this->assertSame('internal', Arr::get($data, 'errors.0.extensions.category'));
     }
@@ -417,7 +417,7 @@ class HandlesGraphqlRequestsTest extends AbstractTestCase
             'query' => 'query { nonExistingClassDependency }',
         ]));
 
-        $this->assertContains(data_get($data, 'errors.0.debugMessage'), [
+        $this->assertContains(data_get($data, 'errors.0.extensions.debugMessage'), [
             "Class Butler\Graphql\Tests\Queries\NonExistingClass does not exist", // Laravel < 6.0
             "Target class [Butler\Graphql\Tests\Queries\NonExistingClass] does not exist.", // Laravel >= 6.0
         ]);


### PR DESCRIPTION
This is a **breaking** change if you use `include_debug_message` or `include_trace`. The fields `debugMessage` and `trace` will no longer be present in the root payload of the errors, but instead under the `extensions: { ... }` object.

This commit also includes PHP 8.4 and Laravel 12 in the test matrix and adds support for `illuminate/support:^12.0` and `phpunit/phpunit:^11.0`.