### PR TITLE
Add support for compiled schema caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Support for caching the compiled schema to improve performance.
+
 
 ## [12.0.1] - 2025-05-13
 

--- a/README.md
+++ b/README.md
@@ -212,6 +212,31 @@ class Attachments
 If none of the above are available Butler GraphQL will resort to the base class name of the data if it's an object.
 
 
+### Caching
+
+To improve the performance as your schema grows and evolves, you can opt-in to caching the compiled schema by overriding `compiledSchemaPath()` in your controller and provide a path to where you want it to be stored:
+
+```php
+<?php
+
+namespace App\Http\Controllers;
+
+use Butler\Graphql\Concerns\HandlesGraphqlRequests;
+
+class GraphqlController extends Controller
+{
+    use HandlesGraphqlRequests;
+
+    public function compiledSchemaPath(): ?string
+    {
+        return app()->isProduction()
+            ? app()->bootstrapPath('cache/graphql-schema-compiled.php')
+            : null;
+    }
+}
+```
+
+
 ### N+1 and the Data Loader
 
 Butler GraphQL includes a simple data loader to prevent n+1 issues when loading nested data. It's available in `$context['loader']` and really easy to use:

--- a/pint.json
+++ b/pint.json
@@ -16,5 +16,8 @@
             "named_class": true
         },
         "php_unit_method_casing": false
-    }
+    },
+    "notPath": [
+        "tests/stubs/schema-compiled.php"
+    ]
 }

--- a/tests/HandlesGraphqlRequestsTest.php
+++ b/tests/HandlesGraphqlRequestsTest.php
@@ -769,6 +769,24 @@ class HandlesGraphqlRequestsTest extends AbstractTestCase
         $this->assertEquals(['foo' => 'bar'], $controller->variables);
     }
 
+    public function test_compiled_schema()
+    {
+        $controller = $this->app->make(GraphqlControllerWithCompiledSchema::class);
+
+        $data = $controller(Request::create('/', 'POST', [
+            'query' => 'query { ping }',
+        ]));
+
+        $this->assertSame(
+            [
+                'data' => [
+                    'ping' => 'pong',
+                ],
+            ],
+            $data
+        );
+    }
+
     public function test_eloquent_strictness()
     {
         if (! method_exists(Model::class, 'preventAccessingMissingAttributes')) {

--- a/tests/stubs/GraphqlControllerWithCompiledSchema.php
+++ b/tests/stubs/GraphqlControllerWithCompiledSchema.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Butler\Graphql\Tests;
+
+use Butler\Graphql\Concerns\HandlesGraphqlRequests;
+use GraphQL\Language\AST\DocumentNode;
+
+class GraphqlControllerWithCompiledSchema
+{
+    use HandlesGraphqlRequests;
+
+    public function parseDocument(): DocumentNode
+    {
+        throw new \Exception('Should never be called if a compiled schema is available.');
+    }
+
+    public function compiledSchemaPath(): ?string
+    {
+        return __DIR__ . '/schema-compiled.php';
+    }
+}

--- a/tests/stubs/schema-compiled.php
+++ b/tests/stubs/schema-compiled.php
@@ -1,0 +1,93 @@
+<?php
+return array (
+  'loc' => 
+  array (
+    'start' => 0,
+    'end' => 33,
+  ),
+  'kind' => 'Document',
+  'definitions' => 
+  array (
+    0 => 
+    array (
+      'loc' => 
+      array (
+        'start' => 0,
+        'end' => 32,
+      ),
+      'kind' => 'ObjectTypeDefinition',
+      'name' => 
+      array (
+        'loc' => 
+        array (
+          'start' => 5,
+          'end' => 10,
+        ),
+        'kind' => 'Name',
+        'value' => 'Query',
+      ),
+      'interfaces' => 
+      array (
+      ),
+      'directives' => 
+      array (
+      ),
+      'fields' => 
+      array (
+        0 => 
+        array (
+          'loc' => 
+          array (
+            'start' => 17,
+            'end' => 30,
+          ),
+          'kind' => 'FieldDefinition',
+          'name' => 
+          array (
+            'loc' => 
+            array (
+              'start' => 17,
+              'end' => 21,
+            ),
+            'kind' => 'Name',
+            'value' => 'ping',
+          ),
+          'arguments' => 
+          array (
+          ),
+          'type' => 
+          array (
+            'loc' => 
+            array (
+              'start' => 23,
+              'end' => 30,
+            ),
+            'kind' => 'NonNullType',
+            'type' => 
+            array (
+              'loc' => 
+              array (
+                'start' => 23,
+                'end' => 29,
+              ),
+              'kind' => 'NamedType',
+              'name' => 
+              array (
+                'loc' => 
+                array (
+                  'start' => 23,
+                  'end' => 29,
+                ),
+                'kind' => 'Name',
+                'value' => 'String',
+              ),
+            ),
+          ),
+          'directives' => 
+          array (
+          ),
+        ),
+      ),
+    ),
+  ),
+);


### PR DESCRIPTION
From README.md:

> ### Caching
> 
> To improve the performance as your schema grows and evolves, you can opt-in to caching the compiled schema by overriding `compiledSchemaPath()` in your controller and provide a path to where you want it to be stored:
> 
> ```php
> <?php
> 
> namespace App\Http\Controllers;
> 
> use Butler\Graphql\Concerns\HandlesGraphqlRequests;
> 
> class GraphqlController extends Controller
> {
>     use HandlesGraphqlRequests;
> 
>     public function compiledSchemaPath(): ?string
>     {
>         return app()->isProduction()
>             ? app()->bootstrapPath('cache/graphql-schema-compiled.php')
>             : null;
>     }
> }
> ```

Reference: https://webonyx.github.io/graphql-php/schema-definition-language/#performance-considerations